### PR TITLE
修复网易云新域名识别和特殊情况下文件名相同的问题

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -184,15 +184,19 @@ func Start(conf map[string]string) (actionCode int) {
 						return 2
 					}
 				}
-			} else if strings.Contains(update.Message.Text, "music.163.com") {
+			} else if strings.Contains(update.Message.Text, "music.163.com") || strings.Contains(update.Message.Text, "163cn.tv") {
 				go func() {
-					id := parseMusicID(updateMsg.Text)
+					var text = update.Message.Text
+					if strings.Contains(update.Message.Text, "163cn.tv") {
+						text = getRedirectUrl(text)
+					}
+					id := parseMusicID(text)
 					if id != 0 {
 						err := processMusic(id, updateMsg, bot)
 						if err != nil {
 							logrus.Errorln(err)
 						}
-					} else if id = parseProgramID(updateMsg.Text); id != 0 {
+					} else if id = parseProgramID(text); id != 0 {
 						if id = getProgramRealID(id); id != 0 {
 							err := processMusic(id, updateMsg, bot)
 							if err != nil {


### PR DESCRIPTION
fix #13 #14 

# 修复 🩹

- 网易云链接匹配遗漏

`分享xx的单曲《xx》: http://163cn.tv/xxx (来自@网易云音乐)`

- 特殊情况下文件名相同
