### PR TITLE
fix: Add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ADD . /build
 
 RUN bash build.sh
 
-FROM scratch AS runner
+FROM alpine:3.21 AS runner
+
+RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
我在使用这个项目的 ghcr.io/xiaomengxinx/music163bot-go 镜像与本地构建的 docker 镜像都会有同样的问题，似乎是 FROM scratch 缺少必要的 ca-certificates ，换成 FROM alpine 就没问题了
```
> docker-compose logs -f
music163bot  | 2025/01/11 13:41:22 [INFO] Music163bot-Go  (main.go:84)
music163bot  | 2025/01/11 13:41:22 [INFO] 加载内置版本  中 (main.go:99)
music163bot  | 2025/01/11 13:41:24 [ERROR] Post "https://api.telegram.org/botxxxxxx/getMe": tls: failed to verify certificate: x509: certificate signed by unknown authority (bot.go:81)
music163bot  | 2025/01/11 13:41:24 [FATAL] Unexpected error (main.go:105)
music163bot exited with code 0
music163bot  | 2025/01/11 13:41:24 [INFO] Music163bot-Go  (main.go:84)
music163bot  | 2025/01/11 13:41:24 [INFO] 加载内置版本  中 (main.go:99)
music163bot  | 2025/01/11 13:41:26 [ERROR] Post "https://api.telegram.org/botxxxxxx/getMe": tls: failed to verify certificate: x509: certificate signed by unknown authority (bot.go:81)
music163bot  | 2025/01/11 13:41:26 [FATAL] Unexpected error (main.go:105)
music163bot exited with code 1
music163bot  | 2025/01/11 13:41:26 [INFO] Music163bot-Go  (main.go:84)
music163bot  | 2025/01/11 13:41:26 [INFO] 加载内置版本  中 (main.go:99)
music163bot  | 2025/01/11 13:41:28 [ERROR] Post "https://api.telegram.org/botxxxxxx/getMe": tls: failed to verify certificate: x509: certificate signed by unknown authority (bot.go:81)
music163bot  | 2025/01/11 13:41:28 [FATAL] Unexpected error (main.go:105)
music163bot exited with code 1
```
