### PR TITLE
修复扩展名问题 & 优化私聊响应

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -208,6 +208,16 @@ func Start(conf map[string]string) (actionCode int) {
 						}
 					}
 				}()
+			} else {
+				// 私聊无需 /music 前缀
+				if updateMsg.Chat.IsPrivate() && update.Message.Command() == "" && updateMsg.Text != "" {
+					go func() {
+						err := processAnyMusic(updateMsg, bot)
+						if err != nil {
+							logrus.Errorln(err)
+						}
+					}()
+				}
 			}
 		case update.CallbackQuery != nil:
 			updateQuery := *update.CallbackQuery

--- a/bot/modules.go
+++ b/bot/modules.go
@@ -74,19 +74,28 @@ func processRmCache(message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) 
 }
 
 func processAnyMusic(message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) {
-	if message.CommandArguments() == "" {
+	var keyword string
+	if message.Chat.IsPrivate() && !message.IsCommand() {
+		keyword = message.Text
+	} else {
+		keyword = message.CommandArguments()
+	}
+
+	if keyword == "" {
 		msg := tgbotapi.NewMessage(message.Chat.ID, inputIDorKeyword)
 		msg.ReplyToMessageID = message.MessageID
 		_, err = bot.Send(msg)
 		return
 	}
-	musicID, _ := strconv.Atoi(message.CommandArguments())
+
+	musicID, _ := strconv.Atoi(keyword)
 	if musicID != 0 {
 		err = processMusic(musicID, message, bot)
 		return err
 	}
+
 	searchResult, _ := api.SearchSong(data, api.SearchSongConfig{
-		Keyword: message.CommandArguments(),
+		Keyword: keyword,
 		Limit:   10,
 	})
 	if len(searchResult.Result.Songs) == 0 {

--- a/bot/processMusic.go
+++ b/bot/processMusic.go
@@ -173,7 +173,12 @@ func processMusic(musicID int, message tgbotapi.Message, bot *tgbotapi.BotAPI) (
 	songInfo.SongArtists = parseArtist(songDetail.Songs[0])
 	songInfo.SongAlbum = songDetail.Songs[0].Al.Name
 	url := songURL.Data[0].Url
-	switch path.Ext(path.Base(url)) {
+	// 从 URL 中移除查询参数以正确获取扩展名
+	baseURL := url
+	if queryIndex := strings.Index(url, "?"); queryIndex != -1 {
+		baseURL = url[:queryIndex]
+	}
+	switch path.Ext(path.Base(baseURL)) {
 	case ".mp3":
 		songInfo.FileExt = "mp3"
 	case ".flac":


### PR DESCRIPTION
- 修复扩展名问题 (Fix #25 )
正确处理链接参数以避免所有文件都被认作为 mp3

- 优化私聊响应
私聊机器人时不带 `/music` 前缀也会自动调用歌曲搜索

<img width="491" alt="image" src="https://github.com/user-attachments/assets/eaf0721a-6ea6-4529-8779-1538a753cb78" />
