### PR TITLE
修复歌曲文件和歌词文件命名不一致的问题

### DIFF
--- a/bot/processLyric.go
+++ b/bot/processLyric.go
@@ -78,7 +78,7 @@ func processLyric(message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) {
 
 	if lyric.Lrc.Lyric != "" && len(detail.Songs) != 0 {
 		var replacer = strings.NewReplacer("/", " ", "?", " ", "*", " ", ":", " ", "|", " ", "\\", " ", "<", " ", ">", " ", "\"", " ")
-		lrcPath := fmt.Sprintf("%s/%s - %s.lrc", cacheDir, replacer.Replace(parseArtist(detail.Songs[0])), replacer.Replace(detail.Songs[0].Name))
+		lrcPath := fmt.Sprintf("%s/%s - %s.lrc", cacheDir, replacer.Replace(strings.Replace(parseArtist(detail.Songs[0]), "/", ",", -1)), replacer.Replace(detail.Songs[0].Name))
 		file, err := os.OpenFile(lrcPath, os.O_WRONLY|os.O_CREATE, 0666)
 		if err != nil {
 			sendFailed()


### PR DESCRIPTION
对bot/processLyric.go中对歌词文件进行命名的部分进行了修改，参照bot/processMusic.go中对歌曲文件的重命名方式。


举例：
修改前：
/music 2119517202 -> Nozomi Kitay,GAL D - Moshi Moshi (feat. 百足).flac
/lyric 2119517202 - > Nozomi Kitay GAL D - Moshi Moshi (feat. 百足).lrc
修改后：
/music 2119517202 -> Nozomi Kitay,GAL D - Moshi Moshi (feat. 百足).flac
/lyric 2119517202 - > Nozomi Kitay,GAL D - Moshi Moshi (feat. 百足).lrc


便于直接使用脚本合并歌词文件