### PR TITLE
feat: 添加频道订阅强制和每日下载限制功能

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -48,6 +48,9 @@ func Start(conf map[string]string) (actionCode int) {
 	db.SetMaxOpenConns(1)
 	defer db.Close()
 
+	// 初始化用户限制配置
+	initUserLimit(config)
+
 	if config["MUSIC_U"] != "" {
 		data = utils.RequestData{
 			Cookies: []*http.Cookie{
@@ -170,6 +173,13 @@ func Start(conf map[string]string) (actionCode int) {
 							logrus.Errorln(err)
 						}
 					}()
+				case "my":
+					go func() {
+						err := processMyStats(updateMsg, bot)
+						if err != nil {
+							logrus.Errorln(err)
+						}
+					}()
 				}
 				if in(fmt.Sprintf("%d", update.Message.From.ID), botAdminStr) {
 					switch update.Message.Command() {
@@ -211,6 +221,27 @@ func Start(conf map[string]string) (actionCode int) {
 			}
 		case update.CallbackQuery != nil:
 			updateQuery := *update.CallbackQuery
+
+			// 处理订阅检查回调
+			if updateQuery.Data == "check_subscription" {
+				go func() {
+					userID := updateQuery.From.ID
+					subscribed, err := checkChannelSubscription(userID)
+					if err != nil {
+						bot.Send(tgbotapi.NewCallback(updateQuery.ID, "检查失败，请稍后重试"))
+						return
+					}
+					if subscribed {
+						bot.Send(tgbotapi.NewCallback(updateQuery.ID, "订阅验证成功！"))
+						// 删除原消息
+						bot.Send(tgbotapi.NewDeleteMessage(updateQuery.Message.Chat.ID, updateQuery.Message.MessageID))
+					} else {
+						bot.Send(tgbotapi.NewCallback(updateQuery.ID, "您还未订阅频道"))
+					}
+				}()
+				continue
+			}
+
 			args := strings.Split(updateQuery.Data, " ")
 			if len(args) < 2 {
 				continue

--- a/bot/db.go
+++ b/bot/db.go
@@ -28,6 +28,16 @@ type SongInfo struct {
 	FromChatName string
 }
 
+// UserStats 用户统计信息
+type UserStats struct {
+	gorm.Model
+	UserID        int64 `gorm:"uniqueIndex"`
+	UserName      string
+	TotalDownload int    // 累计下载数
+	TodayDownload int    // 今日下载数
+	LastResetDate string // 最后重置日期 (格式: YYYY-MM-DD)
+}
+
 func initDB(config map[string]string) (err error) {
 	database := "cache.db"
 	if config["Database"] != "" {
@@ -44,6 +54,11 @@ func initDB(config map[string]string) (err error) {
 	if err != nil {
 		return err
 	}
+	err = db.Table("user_stats").AutoMigrate(&UserStats{})
+	if err != nil {
+		return err
+	}
 	MusicDB = db.Table("song_infos")
+	UserStatsDB = db.Table("user_stats")
 	return err
 }

--- a/bot/init.go
+++ b/bot/init.go
@@ -12,6 +12,9 @@ import (
 // MusicDB 音乐缓存数据库入口
 var MusicDB *gorm.DB
 
+// UserStatsDB 用户统计数据库入口
+var UserStatsDB *gorm.DB
+
 // config 配置文件数据
 var config map[string]string
 
@@ -102,4 +105,15 @@ via @%s`
 
 	fetchingLyric   = "正在获取歌词中"
 	downloadTimeout = `下载超时`
+
+	// 频道订阅和限制相关消息
+	needSubscribe   = `请先订阅频道 @%s 后才能使用本Bot`
+	subscribeButton = `订阅频道`
+	checkSubscribe  = `检查订阅状态`
+	dailyLimitMsg   = `您今日的下载次数已达上限 (%d/%d)，请明天再来`
+	myStatsInfo     = `*\[我的统计\]*
+用户: [%s](tg://user?id=%d)
+今日已下载: %d/%d
+累计下载: %d
+`
 )

--- a/bot/modules.go
+++ b/bot/modules.go
@@ -127,3 +127,37 @@ func processStatus(message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) {
 	_, err = bot.Send(msg)
 	return err
 }
+
+func processMyStats(message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) {
+	userID := message.From.ID
+	userName := message.From.UserName
+	if userName == "" {
+		userName = message.From.FirstName
+	}
+
+	userStats, err := getUserStats(userID)
+	if err != nil {
+		// 用户没有统计信息，创建默认记录
+		userStats = &UserStats{
+			UserID:        userID,
+			UserName:      userName,
+			TotalDownload: 0,
+			TodayDownload: 0,
+			LastResetDate: time.Now().Format("2006-01-02"),
+		}
+	}
+
+	msgText := fmt.Sprintf(myStatsInfo,
+		mdV2Replacer.Replace(userName),
+		userID,
+		userStats.TodayDownload,
+		dailyLimit,
+		userStats.TotalDownload,
+	)
+
+	msg := tgbotapi.NewMessage(message.Chat.ID, msgText)
+	msg.ReplyToMessageID = message.MessageID
+	msg.ParseMode = tgbotapi.ModeMarkdownV2
+	_, err = bot.Send(msg)
+	return err
+}

--- a/bot/processMusic.go
+++ b/bot/processMusic.go
@@ -23,6 +23,32 @@ import (
 var musicLimiter = make(chan bool, 4)
 
 func processMusic(musicID int, message tgbotapi.Message, bot *tgbotapi.BotAPI) (err error) {
+	// 检查频道订阅
+	userID := message.From.ID
+	userName := message.From.UserName
+	if userName == "" {
+		userName = message.From.FirstName
+	}
+
+	subscribed, err := checkChannelSubscription(userID)
+	if err != nil {
+		logrus.Errorln("检查订阅状态失败:", err)
+	}
+	if !subscribed {
+		sendSubscribeMessage(message.Chat.ID, message.MessageID)
+		return nil
+	}
+
+	// 检查每日限制
+	allowed, currentCount, err := checkDailyLimit(userID, userName)
+	if err != nil {
+		logrus.Errorln("检查每日限制失败:", err)
+	}
+	if !allowed {
+		sendDailyLimitMessage(message.Chat.ID, message.MessageID, currentCount)
+		return nil
+	}
+
 	d := downloader.NewDownloader().SetSavePath(cacheDir).SetBreakPoint(true)
 
 	timeout, _ := strconv.Atoi(config["DownloadTimeout"])
@@ -69,6 +95,12 @@ func processMusic(musicID int, message tgbotapi.Message, bot *tgbotapi.BotAPI) (
 		if err != nil {
 			sendFailed(err)
 			return err
+		}
+
+		// 成功发送后增加用户下载计数
+		err = incrementUserDownload(userID, userName)
+		if err != nil {
+			logrus.Errorln("增加用户下载计数失败:", err)
 		}
 
 		deleteMsg := tgbotapi.NewDeleteMessage(msgResult.Chat.ID, msgResult.MessageID)
@@ -295,17 +327,17 @@ func processMusic(musicID int, message tgbotapi.Message, bot *tgbotapi.BotAPI) (
 	}
 
 	var replacer = strings.NewReplacer("/", " ", "?", " ", "*", " ", ":", " ", "|", " ", "\\", " ", "<", " ", ">", " ", "\"", " ")
-	var newDir = cacheDir+"/"+fmt.Sprintf("%d", timeStamp)
+	var newDir = cacheDir + "/" + fmt.Sprintf("%d", timeStamp)
 	fileName := replacer.Replace(fmt.Sprintf("%v - %v.%v", strings.Replace(songInfo.SongArtists, "/", ",", -1), songInfo.SongName, songInfo.FileExt))
-	var filePath = newDir+"/"+fileName
-	err	= os.Mkdir(newDir, os.ModePerm)
+	var filePath = newDir + "/" + fileName
+	err = os.Mkdir(newDir, os.ModePerm)
 	if err != nil {
 		sendFailed(err)
 		return err
-    }
+	}
 	err = os.Rename(cacheDir+"/"+fmt.Sprintf("%d-%s", timeStamp, path.Base(url)), filePath)
 	if err != nil {
-		filePath = cacheDir+"/"+fmt.Sprintf("%d-%s", timeStamp, path.Base(url))
+		filePath = cacheDir + "/" + fmt.Sprintf("%d-%s", timeStamp, path.Base(url))
 	}
 
 	mark := marker.CreateMarker(songDetail.Songs[0], songURL.Data[0])
@@ -344,6 +376,12 @@ func processMusic(musicID int, message tgbotapi.Message, bot *tgbotapi.BotAPI) (
 	err = db.Create(&songInfo).Error // 写入歌曲缓存
 	if err != nil {
 		return err
+	}
+
+	// 成功发送后增加用户下载计数
+	err = incrementUserDownload(userID, userName)
+	if err != nil {
+		logrus.Errorln("增加用户下载计数失败:", err)
 	}
 
 	for _, f := range []string{filePath, resizePicPath, picPath} {

--- a/bot/tools.go
+++ b/bot/tools.go
@@ -139,7 +139,7 @@ func getProgramRealID(programID int) int {
 }
 
 // 获取重定向后的地址
-func getRedirectUrl(text string) (string) {
+func getRedirectUrl(text string) string {
 	var replacer = strings.NewReplacer("\n", "", " ", "")
 	messageText := replacer.Replace(text)
 	musicUrl := regUrl.FindStringSubmatch(messageText)
@@ -149,23 +149,23 @@ func getRedirectUrl(text string) (string) {
 			// 创建新的请求
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
-	 			return text
+				return text
 			}
-   
+
 			// 设置 CheckRedirect 函数来处理重定向
 			client := &http.Client{
-	 		  CheckRedirect: func(req *http.Request, via []*http.Request) error {
-	  			return http.ErrUseLastResponse
-	 		  },
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
 			}
-   
+
 			// 执行请求
 			resp, err := client.Do(req)
 			if err != nil {
-	 		  return text
+				return text
 			}
 			defer resp.Body.Close()
-   
+
 			// 返回最终重定向的网址
 			location := resp.Header.Get("location")
 			return location

--- a/bot/userLimit.go
+++ b/bot/userLimit.go
@@ -1,0 +1,181 @@
+package bot
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+var (
+	requiredChannel string // 必须订阅的频道
+	dailyLimit      int    // 每日下载限制
+)
+
+// initUserLimit 初始化用户限制配置
+func initUserLimit(cfg map[string]string) {
+	requiredChannel = cfg["RequiredChannel"]
+	if requiredChannel == "" {
+		requiredChannel = "stardreammusic" // 默认频道
+	}
+
+	dailyLimit = 10 // 默认每日限制10次
+	if cfg["DailyLimit"] != "" {
+		if limit, err := strconv.Atoi(cfg["DailyLimit"]); err == nil {
+			dailyLimit = limit
+		}
+	}
+}
+
+// checkChannelSubscription 检查用户是否订阅了频道
+func checkChannelSubscription(userID int64) (bool, error) {
+	// 如果没有配置必须订阅的频道，则跳过检查
+	if requiredChannel == "" {
+		return true, nil
+	}
+
+	// 检查用户是否是管理员
+	for _, adminID := range botAdmin {
+		if int64(adminID) == userID {
+			return true, nil
+		}
+	}
+
+	channelUsername := "@" + requiredChannel
+	member, err := bot.GetChatMember(tgbotapi.GetChatMemberConfig{
+		ChatConfigWithUser: tgbotapi.ChatConfigWithUser{
+			ChatID: channelUsername,
+			UserID: userID,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	// 检查用户状态
+	status := member.Status
+	return status == "member" || status == "administrator" || status == "creator", nil
+}
+
+// checkDailyLimit 检查用户是否超过每日下载限制
+func checkDailyLimit(userID int64, userName string) (bool, int, error) {
+	// 管理员不受限制
+	for _, adminID := range botAdmin {
+		if int64(adminID) == userID {
+			return true, 0, nil
+		}
+	}
+
+	today := time.Now().Format("2006-01-02")
+	var userStats UserStats
+
+	// 查询用户统计
+	result := UserStatsDB.Where("user_id = ?", userID).First(&userStats)
+
+	if result.Error != nil {
+		// 如果用户不存在，创建新记录
+		userStats = UserStats{
+			UserID:        userID,
+			UserName:      userName,
+			TotalDownload: 0,
+			TodayDownload: 0,
+			LastResetDate: today,
+		}
+		UserStatsDB.Create(&userStats)
+	} else {
+		// 如果日期不是今天，重置今日下载计数
+		if userStats.LastResetDate != today {
+			userStats.TodayDownload = 0
+			userStats.LastResetDate = today
+			UserStatsDB.Save(&userStats)
+		}
+	}
+
+	// 检查是否超过限制
+	if userStats.TodayDownload >= dailyLimit {
+		return false, userStats.TodayDownload, nil
+	}
+
+	return true, userStats.TodayDownload, nil
+}
+
+// incrementUserDownload 增加用户下载计数
+func incrementUserDownload(userID int64, userName string) error {
+	today := time.Now().Format("2006-01-02")
+	var userStats UserStats
+
+	result := UserStatsDB.Where("user_id = ?", userID).First(&userStats)
+
+	if result.Error != nil {
+		// 如果用户不存在，创建新记录
+		userStats = UserStats{
+			UserID:        userID,
+			UserName:      userName,
+			TotalDownload: 1,
+			TodayDownload: 1,
+			LastResetDate: today,
+		}
+		return UserStatsDB.Create(&userStats).Error
+	}
+
+	// 如果日期不是今天，重置今日下载计数
+	if userStats.LastResetDate != today {
+		userStats.TodayDownload = 0
+		userStats.LastResetDate = today
+	}
+
+	userStats.TodayDownload++
+	userStats.TotalDownload++
+	userStats.UserName = userName
+
+	return UserStatsDB.Save(&userStats).Error
+}
+
+// getUserStats 获取用户统计信息
+func getUserStats(userID int64) (*UserStats, error) {
+	today := time.Now().Format("2006-01-02")
+	var userStats UserStats
+
+	result := UserStatsDB.Where("user_id = ?", userID).First(&userStats)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	// 如果日期不是今天，重置今日下载计数
+	if userStats.LastResetDate != today {
+		userStats.TodayDownload = 0
+		userStats.LastResetDate = today
+		UserStatsDB.Save(&userStats)
+	}
+
+	return &userStats, nil
+}
+
+// sendSubscribeMessage 发送需要订阅频道的消息
+func sendSubscribeMessage(chatID int64, messageID int) {
+	channelLink := fmt.Sprintf("https://t.me/%s", requiredChannel)
+	msg := tgbotapi.NewMessage(chatID, fmt.Sprintf(needSubscribe, requiredChannel))
+	msg.ReplyToMessageID = messageID
+
+	// 创建内联按钮
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonURL(subscribeButton, channelLink),
+		),
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(checkSubscribe, "check_subscription"),
+		),
+	)
+	msg.ReplyMarkup = keyboard
+
+	bot.Send(msg)
+}
+
+// sendDailyLimitMessage 发送每日限制消息
+func sendDailyLimitMessage(chatID int64, messageID int, currentCount int) {
+	msg := tgbotapi.NewMessage(chatID, fmt.Sprintf(dailyLimitMsg, currentCount, dailyLimit))
+	msg.ReplyToMessageID = messageID
+	bot.Send(msg)
+}

--- a/config_example.ini
+++ b/config_example.ini
@@ -36,3 +36,9 @@ DownloadTimeout = 60
 
 # 自定义下载反向代理
 ReverseProxy = 114.5.1.4:8080
+
+# 必须订阅的频道 (不带 @, 默认为 stardreammusic)
+RequiredChannel = stardreammusic
+
+# 每日下载限制 (默认为 10)
+DailyLimit = 10


### PR DESCRIPTION
主要更改：
- 添加用户统计数据模型（UserStats）用于跟踪用户下载记录
- 实现频道订阅检查功能，强制用户订阅 @stardreammusic 频道
- 实现每日下载限制功能，可通过配置调整限制数量
- 添加 /my 命令，用户可查看累计下载和当日限额
- 管理员不受频道订阅和每日限制约束
- 添加配置项 RequiredChannel 和 DailyLimit

新增功能：
- checkChannelSubscription(): 检查用户是否订阅频道
- checkDailyLimit(): 检查用户是否达到每日下载限制
- incrementUserDownload(): 增加用户下载计数
- getUserStats(): 获取用户统计信息
- processMyStats(): 处理 /my 命令显示统计信息
- 自动重置每日下载计数