### PR TITLE
Add MAU badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
       <img src="https://img.shields.io/badge/go%20report-A+-brightgreen.svg?style=flat">
 	</a>
 	<a href="https://github.com/XiaoMengXinX/Music163bot-Go/releases">
-    <img src="https://img.shields.io/github/v/release/XiaoMengXinX/Music163bot-Go?include_prereleases&style=flat-square">
-  </a>
+      <img src="https://img.shields.io/github/v/release/XiaoMengXinX/Music163bot-Go?include_prereleases&style=flat-square">
+  	</a>
+	<a href="https://tgbotmau.quoi.dev/?bot=Music163bot" target="_blank">
+		<img alt="@Music163bot MAU" title="@Music163bot MAU" src="https://tgbotmau.quoi.dev/api/bot/Music163bot/mau/badge?style=flat">
+	</a>
 </p>
 
 ## ✨ 特性
@@ -116,3 +119,4 @@ $ ./Music163bot-Go
 - `/musicid` 或 `/netease` + `音乐ID`  —— 从 MusicID 获取歌曲
 - `/search` + `关键词` —— 搜索歌曲
 - `/about` —— 关于本 bot
+


### PR DESCRIPTION
I believe it's nice to have MAU badge in popular OpenSource bot projects to flex about huge user base.
I discovered that there're no ready to use Telegram-counted (the only real source of truth) MAU badge generators, so I've created my own small service.
As a bonus, it tracks MAU changment history over time and displays it by click.

I've used badge style that fits your existing badges in README, but you can customize badge style on your own using https://tgbotmau.quoi.dev/.

Feel free to reach me out in case of need of any adjustments.